### PR TITLE
Added protocols fs-cp and fs-ln.

### DIFF
--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -38,8 +38,11 @@ def grab(path, filename = None, version = None, protocol = None,
             shell('{} fetch --tags'.format(git))
             shell('{} checkout -q {}'.format(git, version))
 
-    elif protocol in ('nfs'):
+    elif protocol in ('nfs','fs-ln'):
         shell('cp --recursive --symbolic-link {} {}'.format(path, filename))
+
+    elif protocol in ('fs-cp'):
+        shell('cp --recursive {} {}'.format(path, filename))
 
     elif protocol in ('rsync'):
         shell('rsync -a {}/ {}'.format(path, filename))


### PR DESCRIPTION
The protocol used to create a 'linked' distribution is called `nfs`  and works like:
```sh
cp --recursive --synbolic-link src target
```
have added `fs-ln` as an alias for that protocol name, and also added the new protocol `fs-cp` which actually copies.
