### PR TITLE
Added ability source a file local / local.csh

### DIFF
--- a/enable.csh.in
+++ b/enable.csh.in
@@ -36,3 +36,8 @@ cat <<EOF
 * you can change your login shell from csh to bash.                        *
 ****************************************************************************
 EOF
+
+set local_script=komodo_prefix/../local.csh
+if ( -r $local_script) then
+    source $local_script
+endif

--- a/enable.in
+++ b/enable.in
@@ -2,3 +2,8 @@
 export PATH=komodo_prefix/bin${PATH:+:${PATH}}
 export MANPATH=komodo_prefix/share/man:${MANPATH}
 export LD_LIBRARY_PATH=komodo_prefix/lib:komodo_prefix/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+local_script = komodo_prefix/../local
+if [ -e $local_script ]; then
+   source $local_script
+fi


### PR DESCRIPTION
With these changes we can *optionally* put a file `local` (bash) or `local.csh`(csh) alongside the main enable script, which can be used to set additional local variables.