### PR TITLE
Fixed invalid bash assignment

### DIFF
--- a/enable.in
+++ b/enable.in
@@ -3,7 +3,7 @@ export PATH=komodo_prefix/bin${PATH:+:${PATH}}
 export MANPATH=komodo_prefix/share/man:${MANPATH}
 export LD_LIBRARY_PATH=komodo_prefix/lib:komodo_prefix/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
-local_script = komodo_prefix/../local
+local_script=komodo_prefix/../local
 if [ -e $local_script ]; then
    source $local_script
 fi


### PR DESCRIPTION
In bash spaces around the assignment operator is invalid.