### PR TITLE
Set "correct" executable in setuptools

### DIFF
--- a/bin/kmd
+++ b/bin/kmd
@@ -108,7 +108,7 @@ def main(args):
     python_ = os.path.join(args.prefix, args.release, 'root', 'bin', 'python')
     ipython_ = os.path.join(args.prefix, args.release, 'root', 'bin', 'ipython')
     bokeh_ = os.path.join(args.prefix, args.release, 'root', 'bin', 'bokeh')
-    sedfxp = """sed -i '1c#!{0}' {1}"""
+    sedfxp = """sed -i 1c#!{0} {1}"""
     print('\n'*10)
     print('fixup ipython'.center(30).center(60,'='))
     print()

--- a/bin/kmd
+++ b/bin/kmd
@@ -108,7 +108,7 @@ def main(args):
     python_ = os.path.join(args.prefix, args.release, 'root', 'bin', 'python')
     ipython_ = os.path.join(args.prefix, args.release, 'root', 'bin', 'ipython')
     bokeh_ = os.path.join(args.prefix, args.release, 'root', 'bin', 'bokeh')
-    sedfxp = """sed '1c#!{0}' {1} > {1}"""
+    sedfxp = """sed -i '1c#!{0}' {1}"""
     print('\n'*10)
     print('fixup ipython'.center(30).center(60,'='))
     print()

--- a/bin/kmd
+++ b/bin/kmd
@@ -105,6 +105,17 @@ def main(args):
                repo[pkg][ver].get('makeopts')
               ], sudo = args.sudo))
 
+    python_ = os.path.join(args.prefix, args.release, 'root', 'bin', 'python')
+    ipython_ = os.path.join(args.prefix, args.release, 'root', 'bin', 'ipython')
+    bokeh_ = os.path.join(args.prefix, args.release, 'root', 'bin', 'bokeh')
+    sedfxp = """sed '1c#!{0}' {1} > {1}"""
+    print('\n'*10)
+    print('fixup ipython'.center(30).center(60,'='))
+    print()
+    print(sedfxp)
+    komodo.shell(sedfxp.format(python_, ipython_))
+    komodo.shell(sedfxp.format(python_, bokeh_))
+
     # run any post-install scripts on the release
     if args.postinst:
         komodo.shell([args.postinst, os.path.join(args.prefix, args.release)])

--- a/setup-py.sh
+++ b/setup-py.sh
@@ -36,11 +36,13 @@ while test $# -gt 0; do
     shift
 done
 
+PYTHONEXECUTABLE=$PREFIX/bin/python
+
 if [ -n "$REQ" ]; then
     pip install \
-        --global-option build --global-option=--executable=$PYTHON \
+        --global-option build --global-option=--executable=$PYTHONEXECUTABLE \
         --root $FAKEROOT \
         --requirement $REQ --prefix $PREFIX
 fi
-python setup.py build --executable $PYTHON \
+python setup.py build --executable $PYTHONEXECUTABLE \
                 install --prefix $PREFIX --root $FAKEROOT

--- a/setup-wheel.sh
+++ b/setup-wheel.sh
@@ -32,5 +32,5 @@ while test $# -gt 0; do
     shift
 done
 
-python setup.py build --executable $PYTHON \
+python setup.py build --executable $PREFIX/bin/python \
                 install --prefix $PREFIX --root $FAKEROOT


### PR DESCRIPTION
For testing.

Using `--executable $PYTHON` is wrong, `--executable $PREFIX/bin/python` is slightly better.  Should be `--executable $PATH_TO_NEW_PYTHON`.
