### PR TITLE
Add sphinx to postprocess hack

### DIFF
--- a/bin/kmd
+++ b/bin/kmd
@@ -10,6 +10,34 @@ import logging
 
 import komodo
 
+
+def _fixup_python_shebang(args):
+    """Fix shebang to $PREFIX/bin/python.
+
+    Some packages installed with pip do not respect target executable, that is,
+    they set as their shebang executable the Python executabl used to build the
+    komodo distribution with instead of the Python executable that komodo
+    deploys.  This breaks the application since the corresponding Python modules
+    won't be picked up correctly.
+
+    For now, we use sed to rewrite the first line in some executables.
+
+    """
+    # TODO fix hardcoded fix of ipython, bokeh, ...
+    python_ = os.path.join(args.prefix, args.release, 'root', 'bin', 'python')
+
+    # executables with wrong shebang
+    bins_ =  ('ipython', 'bokeh', 'pylint', 'yapf')
+    bins_ += ('sphinx-apidoc', 'sphinx-autogen', 'sphinx-build', 'sphinx-quickstart')
+
+
+    sedfxp = """sed -i 1c#!{0} {1}"""
+    for bin_ in bins_:
+        binpath_ = os.path.join(args.prefix, args.release, 'root', 'bin', bin_)
+        if os.path.exists(binpath_):
+            komodo.shell(sedfxp.format(python_, binpath_))
+
+
 def main(args):
     args.prefix = os.path.abspath(args.prefix)
 
@@ -46,6 +74,7 @@ def main(args):
         if not os.path.exists(tmpl):
             logging.warn('Could not find template %s, skipping.' % str(tmpl))
             continue
+        # TODO should args.release be release_path?
         with open('{}/{}'.format(args.release, target), 'w') as f:
             f.write(komodo.shell(['m4 enable.m4',
                            '-D komodo_prefix={}'.format(tmp_prefix),
@@ -106,15 +135,8 @@ def main(args):
               ], sudo = args.sudo))
 
 
-    # TODO fix hardcoded fix of ipython, bokeh, pylint
-    python_  = os.path.join(args.prefix, args.release, 'root', 'bin', 'python')
-
-    bins_ = ('ipython', 'bokeh', 'pylint', 'yapf')  # executables with wrong shebang
-    sedfxp = """sed -i 1c#!{0} {1}"""
-    for bin_ in bins_:
-        binpath_ = os.path.join(args.prefix, args.release, 'root', 'bin', bin_)
-        komodo.shell(sedfxp.format(python_, binpath_))
-
+    # this is a hack that should be fixed at some point
+    _fixup_python_shebang(args)
 
     # run any post-install scripts on the release
     if args.postinst:


### PR DESCRIPTION
Added `sphinx` to postprocess hack.

This should at some point be fixed by getting `pip` to respect `executable` argument.