### PR TITLE
Add in-place deploy option

### DIFF
--- a/bin/kmd
+++ b/bin/kmd
@@ -71,17 +71,23 @@ def main(args):
     print('Installing {} to {}'.format(args.release, args.prefix))
     install_root = os.path.join(args.prefix, args.release, 'root')
 
-    komodo.shell('{1} {0} .{0} {0}'.format(args.release, args.renamer))
-    komodo.shell('rsync -a .{} {}'.format(args.release, args.prefix), sudo = args.sudo)
+    if args.inplace_deploy:
+        if not komodo.tree_equal(install_root, '{}/root'.format(args.release)):
+            sys.exit('There have been changes in the filesystem layout - in place deploy is not possible.')
 
-    if os.path.exists('{1}/{0}'.format(args.release, args.prefix)):
-        komodo.shell('{2} {0} {0}.delete {1}/{0}'.format(args.release, args.prefix, args.renamer),
-               sudo = args.sudo)
+        komodo.shell('rsync -avc {} {}'.format(args.release, args.prefix), sudo = args.sudo)
+    else:
+        komodo.shell('{1} {0} .{0} {0}'.format(args.release, args.renamer))
+        komodo.shell('rsync -a .{} {}'.format(args.release, args.prefix), sudo = args.sudo)
 
-    komodo.shell('{2} .{0} {0} {1}/.{0}'.format(args.release, args.prefix, args.renamer),
-           sudo = args.sudo)
-    komodo.shell('rm -rf {1}/{0}.delete'.format(args.release, args.prefix),
-           sudo = args.sudo)
+        if os.path.exists('{1}/{0}'.format(args.release, args.prefix)):
+            komodo.shell('{2} {0} {0}.delete {1}/{0}'.format(args.release, args.prefix, args.renamer),
+                         sudo = args.sudo)
+
+        komodo.shell('{2} .{0} {0} {1}/.{0}'.format(args.release, args.prefix, args.renamer),
+                     sudo = args.sudo)
+        komodo.shell('rm -rf {1}/{0}.delete'.format(args.release, args.prefix),
+                     sudo = args.sudo)
 
     # pip hard-codes the interpreter path to whatever interpreter that was used
     # to install it. we want this to be whatever's provided by the komodo
@@ -131,6 +137,7 @@ if __name__ == '__main__':
     parser.add_argument('--build', '-b',    action = 'store_true')
     parser.add_argument('--install', '-i',  action = 'store_true')
     parser.add_argument('--dry-run', '-n',  action = 'store_true')
+    parser.add_argument('--inplace-deploy', '-u',  action = 'store_true')
 
     parser.add_argument('--cmake', type = str, default = 'cmake')
     parser.add_argument('--pip',   type = str, default = 'pip')

--- a/komodo/__init__.py
+++ b/komodo/__init__.py
@@ -50,6 +50,31 @@ def fixup_python_shebangs(prefix, release):
             shell(sedfxp.format(python_, binpath_))
 
 
+# We are typically comparing the filesystem structure on two different
+# filesystems, then it seems that both the os.walk() and the dnames and fnames
+# lists come in different order, that is the reason we sort everything.
+def tree_hash(path):
+    entries = []
+    tail = path.split("/")[-1]
+    path_offset = len(path) - len(tail)
+    for d,dnames,fnames in os.walk(path):
+        root = d[path_offset:]
+        # It seems the .dist-info directories from pip installed pacakges are
+        # not equal in the final installation directory and the fakeroot
+        # installation directory. These driectories are therefor skipped here,
+        # otehrwise the tree_equal() function will always return False.
+        if root.endswith(".dist-info"):
+            continue
+
+        entries.append((root , {"files" : sorted(fnames),
+                                "directories" : sorted(dnames)}))
+    return hash(str(sorted(entries)))
+
+
+def tree_equal(path1, path2):
+    return tree_hash(path1) == tree_hash(path2)
+
+
 __version__ = '1.0'
 __author__ = 'Software Innovation Bergen, Statoil ASA'
 

--- a/tests/test_tree_cmp.py
+++ b/tests/test_tree_cmp.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import os
+import contextlib
+import tempfile
+import unittest
+import shutil
+
+import komodo
+
+@contextlib.contextmanager
+def tmp():
+    cwd0 = os.getcwd()
+    dname = tempfile.NamedTemporaryFile().name
+    os.mkdir(dname)
+    os.chdir(dname)
+
+    yield dname
+
+    os.chdir(cwd0)
+    shutil.rmtree(dname)
+
+
+class TreeTest(unittest.TestCase):
+
+    def test_tree(self):
+        with tmp():
+            os.makedirs("prefix1/stable/root/bin")
+            os.makedirs("prefix2/stable/root/bin")
+
+            with open("prefix1/stable/root/bin/file", "w") as f:
+                f.write("Hello")
+
+
+            self.assertFalse( komodo.tree_equal("prefix1/stable", "prefix2/stable"))
+
+            with open("prefix2/stable/root/bin/file", "w") as f:
+                f.write("Hello")
+
+            self.assertTrue(komodo.tree_equal("prefix1/stable", "prefix2/stable"))
+            os.makedirs("prefix1/stable/root/lib")
+            self.assertFalse( komodo.tree_equal("prefix1/stable", "prefix2/stable"))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a config option: `--inplace-depoly` - when that is set to true the program will check that the file system structure is unchanged (i.e. the same distribution of files & directories) - if that is the case the final installation will be done in-place with:
```
rsync -ac $release /project/res/komodo
```